### PR TITLE
build(sbt): run JUnit tests on `sbt test`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: scala
+sudo: false
+cache:
+  directories:
+    - $HOME/.cache/coursier
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt
+jdk:
+  - openjdk8
+  - openjdk9
+  - openjdk10
+  - openjdk11
+script: |
+    sbt ++$TRAVIS_SCALA_VERSION test

--- a/build.sbt
+++ b/build.sbt
@@ -23,3 +23,6 @@ mappings in (Compile, packageBin) += (baseDirectory.value / "src" / "main" / "li
 mappings in (Compile, packageBin) += (baseDirectory.value / "src" / "main" / "licenses" / "license.tcllib") -> "license.tcllib"
 mappings in (Compile, packageBin) += (baseDirectory.value / "src" / "main" / "licenses" / "license.terms") -> "license.terms"
 mappings in (Compile, packageBin) += (baseDirectory.value / "src" / "main" / "licenses" / "license.ucb") -> "license.ucb"
+
+mainClass in assembly := Some("tcl.lang.Shell")
+test in assembly := {}

--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,8 @@ javacOptions in (Test) ++= javaCompilerOptions
 
 // Library Dependencies
 libraryDependencies += "org.codehaus.janino" % "janino" % "3.0.11"
+libraryDependencies += "junit" % "junit" % "4.13" % Test
+libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % Test
 
 // add license files to jar
 mappings in (Compile, packageBin) += (baseDirectory.value / "src" / "main" / "licenses" / "license.amd") -> "license.amd"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")


### PR DESCRIPTION
Currently sbt does not run JTcl's tests when you execute the command `sbt test` and actually throws an error because there is no JUnit dependency declared.  This PR fixes that.